### PR TITLE
Add a docker-compose config that includes the frontend template

### DIFF
--- a/docker-compose-dev-frontend.yaml
+++ b/docker-compose-dev-frontend.yaml
@@ -1,0 +1,34 @@
+version: '3'
+services:
+  prisma:
+    image: prismagraphql/prisma:1.26
+    ports:
+    - "4466:4466"
+    environment:
+      PRISMA_CONFIG: |
+        port: 4466
+        databases:
+          default:
+            connector: postgres
+            host: postgres
+            port: 5432
+            user: prisma
+            password: prisma
+            migrations: true
+    depends_on:
+      - postgres
+  postgres:
+    image: postgres:10.6
+    ports:
+    - "5432:5432"
+    environment:
+      POSTGRES_USER: prisma
+      POSTGRES_PASSWORD: prisma
+    volumes:
+      - postgres:/var/lib/postgresql/data
+  frontend:
+    image: phanoix/front_end_template:latest
+    ports:
+    - "3000:3000"
+volumes:
+  postgres:


### PR DESCRIPTION
An extended dev docker-compose config, image should be replaced with a front-end image(s) relevant to the service when using the template.